### PR TITLE
Improve heuristics and search limits

### DIFF
--- a/aerobatStats/R/judgeGradeChiSq.R
+++ b/aerobatStats/R/judgeGradeChiSq.R
@@ -23,7 +23,8 @@ jgd.chiSqP <- function(gradeCounts) {
   set_invalid_error <- function(w) {
     rv$valid <<- F
   }
-  clust <- tryCatch(prechi.cluster_neighbors(gradeCounts$range, gradeCounts$counts),
+  clust <- tryCatch(
+      prechi.cluster_neighbors(gradeCounts$range, gradeCounts$counts, 5, 5),
       error=set_invalid_error, warning = set_invalid_error)
   if (rv$valid) {
     rv$df <- clust$count - 3

--- a/prechi/DESCRIPTION
+++ b/prechi/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: prechi
 Title: Prepare judge grade frequency data for
   Chi-Square goodness of fit measurement
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: c(person("Douglas", "Lovell",
   email = "doug@wbreeze.com", role = c("aut", "cre", "cph")))
 Author: Douglas Lovell [aut, cre, cph]

--- a/prechi/R/preChi.R
+++ b/prechi/R/preChi.R
@@ -2,7 +2,12 @@
 # grades: vector of numeric grade values, increasing
 # counts: vector of integer counts
 # minimum_count: integer minimum size of a cluster, defaults to five
-prechi.cluster_neighbors <- function(grades, counts, minimum_count = 5) {
+# timout:  a timeout in seconds. Sending zero will result in a
+#   one hour timeout. The algorithm returns the current result at the
+#   timeout, or the first result found after the timeout.
+prechi.cluster_neighbors <- function(grades, counts,
+  minimum_count = 5, timeout = 0)
+{
   n <- as.integer(minimum_count)
   ln <- length(n)
   if (1 < ln) {
@@ -26,11 +31,12 @@ prechi.cluster_neighbors <- function(grades, counts, minimum_count = 5) {
     g <- g[0:part_ct]
     c <- c[0:part_ct]
   }
+  maxt <- as.integer(timeout)
 
   if (part_ct < 3) {
     stop("Prechi: fewer than three parts provided")
   }
-  clustered <- .Call(pre_chi_cluster_neighbors, g, c, n)
+  clustered <- .Call(pre_chi_cluster_neighbors, g, c, n, maxt)
   if (clustered$count < 3) {
     stop("Prechi: there is no solution with three or more parts")
   }

--- a/prechi/man/prechi.cluster_neighbors.Rd
+++ b/prechi/man/prechi.cluster_neighbors.Rd
@@ -14,7 +14,7 @@
   and bounded by largest possible number of groupings.
 }
 \usage{
-prechi.cluster_neighbors(grades, counts, minimum_count = 5)
+prechi.cluster_neighbors(grades, counts, minimum_count = 5, timeout = 0)
 }
 \arguments{
   \item{grades}{
@@ -30,6 +30,12 @@ prechi.cluster_neighbors(grades, counts, minimum_count = 5)
   Minimum count needed for any grade or combination of grades.
   This defaults to five.
 }
+  \item{timeout}{
+  Maximum time in seconds. Defaults to one hour.
+  Sending zero (the default) will result in a
+  one hour timeout. The algorithm returns the current result at the
+  timeout, or the first result found after the timeout.
+  }
 }
 \details{
   When a grade has a count less than the minimum, this combines counts

--- a/prechi/src/prechi.h
+++ b/prechi/src/prechi.h
@@ -1,6 +1,8 @@
 #ifndef PRECHI_H
 #define PRECHI_H
 
+#include <time.h>
+
 typedef struct Prechi {
   int count;
   float *weights;
@@ -13,11 +15,12 @@ typedef struct Prechi {
   int *solution_counts;
   int *solution_spans;
   float *solution_boundaries;
+  clock_t timeout;
 } Prechi;
 
 Prechi *prechi_create(const double *weights, const int *counts, int count);
 Prechi *prechi_destroy(Prechi *prechi);
 
-void prechi_solve(Prechi *prechi, int min_count);
+void prechi_solve(Prechi *prechi, int min_count, int timeout_seconds);
 
 #endif

--- a/prechi/src/prechi_partition.c
+++ b/prechi/src/prechi_partition.c
@@ -30,11 +30,11 @@ int prechi_partition_minimum(PrechiPartition *part, int offset) {
 /*
  Return the smallest count of a partition.
 */
-int prechi_partition_minimum_count(PrechiPartition *part) {
+int prechi_partition_minimum_count(PrechiPartition *part, int offset) {
   // minimums are the smaller count of neighbors at a boundary
   // sorted_offset has boundary indexes in increasing order of minimum
   return prechi_partition_minimum(
-    part, prechi_partition_sorted_offset(part, 0));
+    part, prechi_partition_sorted_offset(part, offset));
 }
 
 /*

--- a/prechi/src/prechi_partition.h
+++ b/prechi/src/prechi_partition.h
@@ -16,6 +16,7 @@ PrechiPartition *prechi_partition_copy(PrechiPartition *part);
 void prechi_partition_join(PrechiPartition *part, int offset);
 
 int prechi_partition_sorted_offset(PrechiPartition *part, int offset);
+int prechi_partition_minimum(PrechiPartition *part, int offset);
 int prechi_partition_value(PrechiPartition *part, int offset);
 int prechi_partition_minimum_count(PrechiPartition *part);
 float prechi_partition_mean(PrechiPartition *part);

--- a/prechi/src/prechi_partition.h
+++ b/prechi/src/prechi_partition.h
@@ -18,7 +18,7 @@ void prechi_partition_join(PrechiPartition *part, int offset);
 int prechi_partition_sorted_offset(PrechiPartition *part, int offset);
 int prechi_partition_minimum(PrechiPartition *part, int offset);
 int prechi_partition_value(PrechiPartition *part, int offset);
-int prechi_partition_minimum_count(PrechiPartition *part);
+int prechi_partition_minimum_count(PrechiPartition *part, int offset);
 float prechi_partition_mean(PrechiPartition *part);
 float prechi_partition_variance(PrechiPartition *part, float mean);
 

--- a/prechi/src/r-prechi.c
+++ b/prechi/src/r-prechi.c
@@ -9,20 +9,24 @@
  grade_counts is a same size vector of integer counts
  min_size is the minimum number of counts needed for any given grade,
    usually 5.
+ max_seconds is a timeout in seconds. Sending zero will result in a
+   one hour timeout. The algorithm returns the current result at the
+   timeout, or the first result found after the timeout.
  The return is a list with:
    grade_counts: vector of clustered, integer counts
    boundaries: vector of real number partition boundaries
 */
 SEXP pre_chi_cluster_neighbors(
-  SEXP grade_values, SEXP grade_counts, SEXP min_size)
+  SEXP grade_values, SEXP grade_counts, SEXP min_size, SEXP max_seconds)
 {
   int n = length(grade_values);
   const double *grades = REAL_RO(grade_values);
   const int *counts = INTEGER_RO(grade_counts);
   int minimum_count = INTEGER_RO(min_size)[0];
+  int maximum_seconds = INTEGER_RO(max_seconds)[0];
 
   Prechi *prechi = prechi_create(grades, counts, n);
-  prechi_solve(prechi, minimum_count);
+  prechi_solve(prechi, minimum_count, maximum_seconds);
 
   int part_ct = prechi->solution_part_count;
   int prct = 0;
@@ -88,7 +92,7 @@ SEXP pre_chi_cluster_neighbors(
 }
 
 static const R_CallMethodDef PreChiEntries[] = {
-  {"pre_chi_cluster_neighbors", (DL_FUNC)&pre_chi_cluster_neighbors, 3},
+  {"pre_chi_cluster_neighbors", (DL_FUNC)&pre_chi_cluster_neighbors, 4},
   {NULL, NULL, 0}
 };
 

--- a/prechi/test/test_partition_sort.c
+++ b/prechi/test/test_partition_sort.c
@@ -117,9 +117,12 @@ void test_partition_minimum_count(void) {
     min+4, min+3, min+2, min+1, min+4, min+5, min, min+7, min+5);
 
   PrechiPartition *part = prechi_partition_create(n, td->weights, td->counts);
+
+  cut_assert_equal_int(min, prechi_partition_minimum_count(part, 0));
+  cut_assert_equal_int(min, prechi_partition_minimum_count(part, 1));
+  cut_assert_equal_int(min+1, prechi_partition_minimum_count(part, 2));
+  cut_assert_equal_int(min+1, prechi_partition_minimum_count(part, 3));
+
   destroy_test_data(td);
-
-  cut_assert_equal_int(min, prechi_partition_minimum_count(part));
-
   prechi_partition_destroy(part);
 }

--- a/prechi/test/test_prechi_solve.c
+++ b/prechi/test/test_prechi_solve.c
@@ -11,7 +11,7 @@ void test_prechi_solve_1(void) {
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
   int expected_parts = 3;
-  prechi_solve(prechi, 5);
+  prechi_solve(prechi, 5, 5);
   cut_assert_equal_int(expected_parts, prechi->solution_part_count);
 
   //re-use counts for span check
@@ -33,7 +33,7 @@ void test_prechi_solve_2(void) {
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
   int expected_parts = 3;
-  prechi_solve(prechi, 5);
+  prechi_solve(prechi, 5, 5);
   cut_assert_equal_int(expected_parts, prechi->solution_part_count);
 
   //re-use counts for span check
@@ -55,7 +55,7 @@ void test_prechi_solve_3(void) {
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
   int expected_parts = 5;
-  prechi_solve(prechi, 5);
+  prechi_solve(prechi, 5, 5);
   cut_assert_equal_int(expected_parts, prechi->solution_part_count);
 
   //re-use counts for span check
@@ -73,25 +73,19 @@ void test_prechi_solve_3(void) {
 }
 
 void test_prechi_solve_long(void) {
-  cut_pend("timing test");
   int n = 15;
   TestData *td = create_test_data(n);
   int_array_init(td->counts, n, 2, 0, 0, 0, 3, 0, 0, 0, 2, 3, 5, 1, 4, 2, 8);
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
   int expected_parts = 5;
-  prechi_solve(prechi, 5);
+  prechi_solve(prechi, 5, 5);
   cut_assert_equal_int(expected_parts, prechi->solution_part_count);
 
-  //re-use counts for span check
-  int_array_init(td->counts, expected_parts, 5, 5, 5, 7, 8);
+  //re-use counts for solution count check
+  int_array_init(td->counts, expected_parts, 5, 5, 6, 6, 8);
   assert_equal_int_arrays(
-    td->counts, prechi->solution_spans, expected_parts);
-
-  assert_equal_float(td->weights[4] + 2.5, prechi->solution_boundaries[0], 2);
-  assert_equal_float(td->weights[9] + 2.5, prechi->solution_boundaries[1], 2);
-  assert_equal_float(td->weights[10] + 2.5, prechi->solution_boundaries[2], 2);
-  assert_equal_float(td->weights[13] + 2.5, prechi->solution_boundaries[3], 2);
+    td->counts, prechi->solution_counts, expected_parts);
 
   prechi_destroy(prechi);
   destroy_test_data(td);
@@ -104,7 +98,7 @@ void test_prechi_solve_no_solution(void) {
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
   destroy_test_data(td);
 
-  prechi_solve(prechi, 5);
+  prechi_solve(prechi, 5, 5);
   cut_assert_equal_int(0, prechi->solution_part_count);
   assert_equal_float(0, prechi->solution_mean, 1);
   assert_equal_float(0, prechi->solution_variance, 1);

--- a/prechi/test/test_prechi_solve.c
+++ b/prechi/test/test_prechi_solve.c
@@ -72,7 +72,8 @@ void test_prechi_solve_3(void) {
   destroy_test_data(td);
 }
 
-void test_prechi_solve_4(void) {
+void test_prechi_solve_long(void) {
+  cut_pend("timing test");
   int n = 15;
   TestData *td = create_test_data(n);
   int_array_init(td->counts, n, 2, 0, 0, 0, 3, 0, 0, 0, 2, 3, 5, 1, 4, 2, 8);

--- a/prechi/test/test_prechi_solve.c
+++ b/prechi/test/test_prechi_solve.c
@@ -72,6 +72,30 @@ void test_prechi_solve_3(void) {
   destroy_test_data(td);
 }
 
+void test_prechi_solve_4(void) {
+  int n = 15;
+  TestData *td = create_test_data(n);
+  int_array_init(td->counts, n, 2, 0, 0, 0, 3, 0, 0, 0, 2, 3, 5, 1, 4, 2, 8);
+  Prechi *prechi = prechi_create(td->dweights, td->counts, n);
+
+  int expected_parts = 5;
+  prechi_solve(prechi, 5);
+  cut_assert_equal_int(expected_parts, prechi->solution_part_count);
+
+  //re-use counts for span check
+  int_array_init(td->counts, expected_parts, 5, 5, 5, 7, 8);
+  assert_equal_int_arrays(
+    td->counts, prechi->solution_spans, expected_parts);
+
+  assert_equal_float(td->weights[4] + 2.5, prechi->solution_boundaries[0], 2);
+  assert_equal_float(td->weights[9] + 2.5, prechi->solution_boundaries[1], 2);
+  assert_equal_float(td->weights[10] + 2.5, prechi->solution_boundaries[2], 2);
+  assert_equal_float(td->weights[13] + 2.5, prechi->solution_boundaries[3], 2);
+
+  prechi_destroy(prechi);
+  destroy_test_data(td);
+}
+
 void test_prechi_solve_no_solution(void) {
   int n = 7;
   TestData *td = create_test_data(n);


### PR DESCRIPTION
Closes #3 

Try the suggestions from the issue. First, add the second level sort to the partition locations. Second, prevent trying partition joins where both sides are at or above the minimum.