### PR TITLE
Preprocess zero runs

### DIFF
--- a/prechi/src/prechi.h
+++ b/prechi/src/prechi.h
@@ -16,6 +16,7 @@ typedef struct Prechi {
   int *solution_spans;
   float *solution_boundaries;
   clock_t timeout;
+  int did_timeout;
 } Prechi;
 
 Prechi *prechi_create(const double *weights, const int *counts, int count);

--- a/prechi/src/r-prechi.c
+++ b/prechi/src/r-prechi.c
@@ -32,8 +32,8 @@ SEXP pre_chi_cluster_neighbors(
   int prct = 0;
 
   // Set-up the returned list
-  SEXP rv = PROTECT(allocVector(VECSXP, 7)); ++prct;
-  SEXP names = PROTECT(allocVector(STRSXP, 7)); ++prct;
+  SEXP rv = PROTECT(allocVector(VECSXP, 8)); ++prct;
+  SEXP names = PROTECT(allocVector(STRSXP, 8)); ++prct;
   SET_STRING_ELT(names, 0, mkChar("count"));
   SET_STRING_ELT(names, 1, mkChar("boundaries"));
   SET_STRING_ELT(names, 2, mkChar("counts"));
@@ -41,6 +41,7 @@ SEXP pre_chi_cluster_neighbors(
   SET_STRING_ELT(names, 4, mkChar("target_variance"));
   SET_STRING_ELT(names, 5, mkChar("solution_mean"));
   SET_STRING_ELT(names, 6, mkChar("solution_variance"));
+  SET_STRING_ELT(names, 7, mkChar("did_timeout"));
   setAttrib(rv, R_NamesSymbol, names);
 
   // Set count on returned list
@@ -85,6 +86,11 @@ SEXP pre_chi_cluster_neighbors(
   SEXP solution_variance = PROTECT(allocVector(REALSXP, 1)); ++prct;
   REAL(solution_variance)[0] = prechi->solution_variance;
   SET_VECTOR_ELT(rv, 6, solution_variance);
+
+  // Set timeout indicator on returned list
+  SEXP timeout = PROTECT(allocVector(LGLSXP, 1)); ++prct;
+  LOGICAL(timeout)[0] = prechi->did_timeout != 0;
+  SET_VECTOR_ELT(rv, 7, timeout);
 
   prechi_destroy(prechi);
   UNPROTECT(prct);

--- a/prechi/test/Makefile.am
+++ b/prechi/test/Makefile.am
@@ -10,10 +10,8 @@ libtest_prechi_la_LDFLAGS = -module -rpath $(libdir) \
 libtest_prechi_la_LIBADD = $(CUTTER_LIBS)
 
 SRC_FILES = \
-../src/prechi.h \
-../src/prechi.c \
-../src/prechi_partition.h \
-../src/prechi_partition.c
+../src/prechi.h ../src/prechi.c \
+../src/prechi_partition.h ../src/prechi_partition.c
 
 libtest_prechi_la_SOURCES = $(SRC_FILES) \
   array_init.h array_init.c \
@@ -23,4 +21,5 @@ libtest_prechi_la_SOURCES = $(SRC_FILES) \
   test_partition_mean.c \
   test_partition_sort.c \
   test_prechi.h test_prechi.c \
+  test_prechi_collapse_zero.c \
   test_prechi_solve.c

--- a/prechi/test/test_prechi_collapse_zero.c
+++ b/prechi/test/test_prechi_collapse_zero.c
@@ -1,0 +1,17 @@
+#include <cutter.h>
+#include "array_init.h"
+#include "test_helper.h"
+#include "test_data.h"
+#include "../src/prechi.h"
+
+void test_prechi_join_zeros(void) {
+  int n = 14;
+  TestData *td = create_test_data(n);
+  int_array_init(td->counts, n, 5, 0, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 5);
+  Prechi *prechi = prechi_create(td->dweights, td->counts, n);
+
+  prechi_solve(prechi, 5, 1);
+
+  cut_assert_false(prechi->did_timeout);
+  cut_assert_equal_int(4, prechi->solution_part_count);
+}

--- a/prechi/test/test_prechi_solve.c
+++ b/prechi/test/test_prechi_solve.c
@@ -72,18 +72,21 @@ void test_prechi_solve_3(void) {
   destroy_test_data(td);
 }
 
-void test_prechi_solve_long(void) {
+void test_prechi_solve_timeout(void) {
   int n = 15;
   TestData *td = create_test_data(n);
-  int_array_init(td->counts, n, 2, 0, 0, 0, 3, 0, 0, 0, 2, 3, 5, 1, 4, 2, 8);
+  int_array_init(td->counts, n, 2, 1, 1, 1, 3, 1, 1, 1, 2, 3, 5, 1, 4, 2, 8);
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
-  int expected_parts = 5;
-  prechi_solve(prechi, 5, 5);
+  prechi_solve(prechi, 5, 1);
+
+  cut_assert_true(prechi->did_timeout);
+
+  int expected_parts = 6;
   cut_assert_equal_int(expected_parts, prechi->solution_part_count);
 
   //re-use counts for solution count check
-  int_array_init(td->counts, expected_parts, 5, 5, 6, 6, 8);
+  int_array_init(td->counts, expected_parts, 5, 5, 6, 6, 6, 8);
   assert_equal_int_arrays(
     td->counts, prechi->solution_counts, expected_parts);
 

--- a/prechi/test/testthat/testPreChi.R
+++ b/prechi/test/testthat/testPreChi.R
@@ -8,7 +8,8 @@ test_that("computes clusters", {
   expect_false(is.null(clustered))
   expect_type(clustered, "list")
   expect_named(clustered, c("count", "boundaries", "counts",
-    "target_mean", "target_variance", "solution_mean", "solution_variance"))
+    "target_mean", "target_variance", "solution_mean", "solution_variance",
+    "did_timeout"))
   expect_length(clustered$count, 1)
   expect_equal(4, clustered$count)
   expect_length(clustered$counts, 4)
@@ -22,6 +23,7 @@ test_that("computes clusters", {
   expect_gt(clustered$boundaries[4], 75)
   expect_lt(clustered$boundaries[4], 80)
   expect_equal(Inf, clustered$boundaries[5])
+  expect_false(clustered$did_timeout)
 })
 
 test_that("computes parameters for normal distribution", {


### PR DESCRIPTION
Closes #5 

The partitions are sorted by minimum count and then merge size; so, simply joining the first n partitions with minimum count of zero, before starting the search, does the trick.

While at it, removed the reduction count, which was an indirect tracking of the trial partition size, and which no longer matched given the preprocessing. It needed to go.

Also added a timeout indicator so that the caller can know whether the entire search space was explored.