### PR TITLE
Parameterize minimum partition count

### DIFF
--- a/prechi/DESCRIPTION
+++ b/prechi/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: prechi
 Title: Prepare judge grade frequency data for
   Chi-Square goodness of fit measurement
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: c(person("Douglas", "Lovell",
   email = "doug@wbreeze.com", role = c("aut", "cre", "cph")))
 Author: Douglas Lovell [aut, cre, cph]

--- a/prechi/R/preChi.R
+++ b/prechi/R/preChi.R
@@ -6,7 +6,7 @@
 #   one hour timeout. The algorithm returns the current result at the
 #   timeout, or the first result found after the timeout.
 prechi.cluster_neighbors <- function(grades, counts,
-  minimum_count = 5, timeout = 0)
+  minimum_count = 5, timeout = 0, minimum_partition_count = 3)
 {
   n <- as.integer(minimum_count)
   ln <- length(n)
@@ -32,13 +32,14 @@ prechi.cluster_neighbors <- function(grades, counts,
     c <- c[0:part_ct]
   }
   maxt <- as.integer(timeout)
+  min_parts <- max(as.integer(3), as.integer(minimum_partition_count))
 
-  if (part_ct < 3) {
-    stop("Prechi: fewer than three parts provided")
+  if (part_ct < min_parts) {
+    stop("Prechi: fewer than ", min_parts, " parts provided")
   }
-  clustered <- .Call(pre_chi_cluster_neighbors, g, c, n, maxt)
-  if (clustered$count < 3) {
-    stop("Prechi: there is no solution with three or more parts")
+  clustered <- .Call(pre_chi_cluster_neighbors, g, c, n, maxt, min_parts)
+  if (clustered$count < min_parts) {
+    stop("Prechi: there is no solution with ", min_parts, " or more parts")
   }
   clustered
 }

--- a/prechi/man/prechi.cluster_neighbors.Rd
+++ b/prechi/man/prechi.cluster_neighbors.Rd
@@ -14,35 +14,40 @@
   and bounded by largest possible number of groupings.
 }
 \usage{
-prechi.cluster_neighbors(grades, counts, minimum_count = 5, timeout = 0)
+prechi.cluster_neighbors(grades, counts, minimum_count = 5, timeout = 0,
+  minimum_partition_count = 3)
 }
 \arguments{
   \item{grades}{
   A vector of grade values, increasing. It should include all of
   the grade values within the domain of grades from the least
   grade given to the greatest.
-}
+  }
   \item{counts}{
   A vector of integer counts, one per grade. The counts are the
   number of times the grade was given.
-}
+  }
   \item{minimum_count}{
   Minimum count needed for any grade or combination of grades.
   This defaults to five.
-}
+  }
   \item{timeout}{
   Maximum time in seconds. Defaults to one hour.
   Sending zero (the default) will result in a
   one hour timeout. The algorithm returns the current result at the
   timeout, or the first result found after the timeout.
   }
+  \item{minimum_partition_count}{
+  Minimum number of partitions in the solution.
+  This defaults to three.
+  }
 }
 \details{
   When a grade has a count less than the minimum, this combines counts
   with that of a neighboring grade. The process repeats
   until there are no grades that have fewer than the
-  minimum count. With a solution or minimum of three clusters, it
-  backtracks to seach all other solutions.
+  minimum count. With a solution or minimum of minimum_partition_count
+  clusters, it backtracks to seach all other solutions.
 
   The search uses the heuristic of choosing to first try joining grades
   with the smallest counts. It bounds the search using number of joins.

--- a/prechi/src/prechi.h
+++ b/prechi/src/prechi.h
@@ -17,11 +17,18 @@ typedef struct Prechi {
   float *solution_boundaries;
   clock_t timeout;
   int did_timeout;
+  float timeout_seconds;
+  int min_solution_part_count; // minimum number of partitions
+  int min_count; // minimum count value in a partition
 } Prechi;
 
 Prechi *prechi_create(const double *weights, const int *counts, int count);
 Prechi *prechi_destroy(Prechi *prechi);
 
-void prechi_solve(Prechi *prechi, int min_count, int timeout_seconds);
+void prechi_set_minimum_partition_count(Prechi *prechi, int min_count);
+void prechi_set_minimum_count(Prechi *prechi, int min_count);
+void prechi_set_timeout_seconds(Prechi *prechi, float seconds);
+
+void prechi_solve(Prechi *prechi);
 
 #endif

--- a/prechi/src/r-prechi.c
+++ b/prechi/src/r-prechi.c
@@ -12,21 +12,27 @@
  max_seconds is a timeout in seconds. Sending zero will result in a
    one hour timeout. The algorithm returns the current result at the
    timeout, or the first result found after the timeout.
+ min_parts_count is the minimum number of partitions required for the solution
  The return is a list with:
    grade_counts: vector of clustered, integer counts
    boundaries: vector of real number partition boundaries
 */
 SEXP pre_chi_cluster_neighbors(
-  SEXP grade_values, SEXP grade_counts, SEXP min_size, SEXP max_seconds)
+  SEXP grade_values, SEXP grade_counts, SEXP min_size, SEXP max_seconds,
+  SEXP min_parts_count)
 {
   int n = length(grade_values);
   const double *grades = REAL_RO(grade_values);
   const int *counts = INTEGER_RO(grade_counts);
   int minimum_count = INTEGER_RO(min_size)[0];
   int maximum_seconds = INTEGER_RO(max_seconds)[0];
+  int minimum_parts = INTEGER_RO(min_parts_count)[0];
 
   Prechi *prechi = prechi_create(grades, counts, n);
-  prechi_solve(prechi, minimum_count, maximum_seconds);
+  prechi_set_minimum_partition_count(prechi, minimum_parts);
+  prechi_set_minimum_count(prechi, minimum_count);
+  prechi_set_timeout_seconds(prechi, maximum_seconds);
+  prechi_solve(prechi);
 
   int part_ct = prechi->solution_part_count;
   int prct = 0;
@@ -98,7 +104,7 @@ SEXP pre_chi_cluster_neighbors(
 }
 
 static const R_CallMethodDef PreChiEntries[] = {
-  {"pre_chi_cluster_neighbors", (DL_FUNC)&pre_chi_cluster_neighbors, 4},
+  {"pre_chi_cluster_neighbors", (DL_FUNC)&pre_chi_cluster_neighbors, 5},
   {NULL, NULL, 0}
 };
 

--- a/prechi/test/Makefile.am
+++ b/prechi/test/Makefile.am
@@ -22,4 +22,5 @@ libtest_prechi_la_SOURCES = $(SRC_FILES) \
   test_partition_sort.c \
   test_prechi.h test_prechi.c \
   test_prechi_collapse_zero.c \
+  test_prechi_no_solution.c \
   test_prechi_solve.c

--- a/prechi/test/test_prechi_collapse_zero.c
+++ b/prechi/test/test_prechi_collapse_zero.c
@@ -10,7 +10,8 @@ void test_prechi_join_zeros(void) {
   int_array_init(td->counts, n, 5, 0, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 5);
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
-  prechi_solve(prechi, 5, 1);
+  prechi_set_timeout_seconds(prechi, 1);
+  prechi_solve(prechi);
 
   cut_assert_false(prechi->did_timeout);
   cut_assert_equal_int(4, prechi->solution_part_count);

--- a/prechi/test/test_prechi_no_solution.c
+++ b/prechi/test/test_prechi_no_solution.c
@@ -1,0 +1,37 @@
+#include <cutter.h>
+#include "array_init.h"
+#include "test_helper.h"
+#include "test_data.h"
+#include "../src/prechi.h"
+
+void test_prechi_solve_no_solution(void) {
+  int n = 7;
+  TestData *td = create_test_data(n);
+  int_array_init(td->counts, n, 1, 0, 4, 0, 4, 0, 1);
+  Prechi *prechi = prechi_create(td->dweights, td->counts, n);
+
+  prechi_solve(prechi);
+  cut_assert_equal_int(0, prechi->solution_part_count);
+  assert_equal_float(0, prechi->solution_mean, 1);
+  assert_equal_float(0, prechi->solution_variance, 1);
+
+  destroy_test_data(td);
+  prechi_destroy(prechi);
+}
+
+void test_prechi_solve_no_solution_six_bins(void) {
+  int n = 7;
+  TestData *td = create_test_data(n);
+  int_array_init(td->counts, n, 1, 4, 4, 1, 5, 5, 5);
+  Prechi *prechi = prechi_create(td->dweights, td->counts, n);
+
+  prechi_set_minimum_partition_count(prechi, 6);
+  prechi_solve(prechi);
+
+  cut_assert_equal_int(0, prechi->solution_part_count);
+  assert_equal_float(0, prechi->solution_mean, 1);
+  assert_equal_float(0, prechi->solution_variance, 1);
+
+  destroy_test_data(td);
+  prechi_destroy(prechi);
+}

--- a/prechi/test/test_prechi_solve.c
+++ b/prechi/test/test_prechi_solve.c
@@ -4,14 +4,18 @@
 #include "test_data.h"
 #include "../src/prechi.h"
 
+#define TIMEOUT_SECONDS 1
+
 void test_prechi_solve_1(void) {
   int n = 5;
   TestData *td = create_test_data(n);
   int_array_init(td->counts, n, 2, 3, 5, 3, 2);
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
+  prechi_set_timeout_seconds(prechi, TIMEOUT_SECONDS);
+  prechi_solve(prechi);
+
   int expected_parts = 3;
-  prechi_solve(prechi, 5, 5);
   cut_assert_equal_int(expected_parts, prechi->solution_part_count);
 
   //re-use counts for span check
@@ -32,8 +36,10 @@ void test_prechi_solve_2(void) {
   int_array_init(td->counts, n, 1, 0, 4, 0, 6, 8, 2);
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
+  prechi_set_timeout_seconds(prechi, TIMEOUT_SECONDS);
+  prechi_solve(prechi);
+
   int expected_parts = 3;
-  prechi_solve(prechi, 5, 5);
   cut_assert_equal_int(expected_parts, prechi->solution_part_count);
 
   //re-use counts for span check
@@ -54,8 +60,10 @@ void test_prechi_solve_3(void) {
   int_array_init(td->counts, n, 6, 8, 1, 1, 1, 1, 1, 7, 5);
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
+  prechi_set_timeout_seconds(prechi, TIMEOUT_SECONDS);
+  prechi_solve(prechi);
+
   int expected_parts = 5;
-  prechi_solve(prechi, 5, 5);
   cut_assert_equal_int(expected_parts, prechi->solution_part_count);
 
   //re-use counts for span check
@@ -78,7 +86,8 @@ void test_prechi_solve_timeout(void) {
   int_array_init(td->counts, n, 2, 1, 1, 1, 3, 1, 1, 1, 2, 3, 5, 1, 4, 2, 8);
   Prechi *prechi = prechi_create(td->dweights, td->counts, n);
 
-  prechi_solve(prechi, 5, 1);
+  prechi_set_timeout_seconds(prechi, TIMEOUT_SECONDS);
+  prechi_solve(prechi);
 
   cut_assert_true(prechi->did_timeout);
 
@@ -92,19 +101,4 @@ void test_prechi_solve_timeout(void) {
 
   prechi_destroy(prechi);
   destroy_test_data(td);
-}
-
-void test_prechi_solve_no_solution(void) {
-  int n = 7;
-  TestData *td = create_test_data(n);
-  int_array_init(td->counts, n, 1, 0, 4, 0, 4, 0, 1);
-  Prechi *prechi = prechi_create(td->dweights, td->counts, n);
-  destroy_test_data(td);
-
-  prechi_solve(prechi, 5, 5);
-  cut_assert_equal_int(0, prechi->solution_part_count);
-  assert_equal_float(0, prechi->solution_mean, 1);
-  assert_equal_float(0, prechi->solution_variance, 1);
-
-  prechi_destroy(prechi);
 }

--- a/prechi/test/testthat/testPreChi.R
+++ b/prechi/test/testthat/testPreChi.R
@@ -83,7 +83,17 @@ test_that("no solution", {
   minimum_count <- c(5)
   expect_error(
     clustered <- prechi.cluster_neighbors(grades, counts, minimum_count),
-    "Prechi: there is no solution with three or more parts")
+    "Prechi: there is no solution with 3 or more parts")
+})
+
+test_that("no bigger solution", {
+  grades <- c(55, 60, 65, 70, 75, 80)
+  counts <- c( 6,  1,  6,  6,  1,  6)
+  minimum_count <- c(6)
+  expect_error(
+    clustered <- prechi.cluster_neighbors(grades, counts, minimum_count,
+      minimum_partition_count = 5),
+    "Prechi: there is no solution with 5 or more parts")
 })
 
 test_that("too few parts", {
@@ -91,7 +101,16 @@ test_that("too few parts", {
   counts <- c( 7,  5)
   expect_error(
     clustered <- prechi.cluster_neighbors(grades, counts),
-    "Prechi: fewer than three parts provided")
+    "Prechi: fewer than 3 parts provided")
+})
+
+test_that("too few of more parts", {
+  grades <- c(55, 60, 65, 70)
+  counts <- c( 7,  5,  8,  8)
+  expect_error(
+    clustered <- prechi.cluster_neighbors(grades, counts,
+      minimum_partition_count = 5),
+    "Prechi: fewer than 5 parts provided")
 })
 
 test_that("zero parts", {
@@ -99,5 +118,5 @@ test_that("zero parts", {
   counts <- c()
   expect_error(
     clustered <- prechi.cluster_neighbors(grades, counts),
-    "Prechi: fewer than three parts provided")
+    "Prechi: fewer than 3 parts provided")
 })


### PR DESCRIPTION
Closes #6 

Now the minimum count of partitions can be something higher than three.

The number of parameters was now three. The calls were repeating the parameter values over and over. So, I made setters.